### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/GlorYouth/seal-crypto/security/code-scanning/1](https://github.com/GlorYouth/seal-crypto/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily reads repository contents and does not require write access, the permissions can be limited to `contents: read`. This ensures the `GITHUB_TOKEN` has only the necessary access to complete the tasks.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. Alternatively, it can be added to the specific job (`test`) if different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
